### PR TITLE
improve example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ https://github.com/Shougo/ddc.vim
 call ddc#custom#patch_global('sources', ['nvimlsp'])
 call ddc#custom#patch_global('sourceOptions', {
       \ '_': {'matchers': ['matcher_head']},
-      \ 'nvimlsp': {'mark': 'lsp', 'forceCompletionPattern': '\.|:|->'},
+      \ 'nvimlsp': {'mark': 'lsp', 'forceCompletionPattern': '(\\.|:|->)'},
       \ })
 
 " Use icon


### PR DESCRIPTION
- Regexp '.' must be escaped with two '\\'.
- `forceCompletionPatten` is used with '$' in ddc, but '$' only works with '->' if the patterns are not grouped.