### PR TITLE
Fix error when disable completion of lsp

### DIFF
--- a/lua/ddc_nvim_lsp.lua
+++ b/lua/ddc_nvim_lsp.lua
@@ -1,11 +1,15 @@
 local api = vim.api
 
 local get_candidates = function(_, _, result)
+  if not result or result == 0 then
+    return
+  end
+
   local success = (type(result) == 'table' and not vim.tbl_isempty(result)
     ) and true or false
-  result = result and result['items'] ~= nil and result['items'] or result
+  result = result['items'] ~= nil and result['items'] or result
 
-  if result and #result > 0 then
+  if #result > 0 then
     api.nvim_set_var('ddc#source#lsp#_results', result)
     api.nvim_set_var('ddc#source#lsp#_success', success)
     api.nvim_set_var('ddc#source#lsp#_requested', true)


### PR DESCRIPTION
When disable completion of solargraph, error occurred. This change make resolve.

## Error content

```
[denops] Error: Failed to call 'onEvent' with ["TextChangedI"]: BatchError: Vim:E5108: Error executing lua ...epos/github.com/Shougo/ddc-nvim-lsp/lua/ddc_nvim_lsp.lua:6: attempt to index local 'result' (a number value)
[denops]     at DenopsImpl.batch (file:///Users/ippachi/.cache/dein/repos/github.com/vim-denops/denops.vim/denops/@denops/denops.ts:157:13)
[denops]     at async batch (https://deno.land/x/denops_std@v1.0.1/helper/batch.ts:71:44)
[denops]     at async Source.gatherCandidates (file:///Users/ippachi/.cache/dein/repos/github.com/Shougo/ddc-nvim-lsp/denops/ddc/sources/nvimlsp.ts:103:44)
[denops]     at async file:///Users/ippachi/.cache/dein/repos/github.com/Shougo/ddc.vim/denops/ddc/ddc.ts:264:18
[denops]     at async Promise.all (index 0)
[denops]     at async Ddc.gatherResults (file:///Users/ippachi/.cache/dein/repos/github.com/Shougo/ddc.vim/denops/ddc/ddc.ts:218:13)
[denops]     at async doCompletion (file:///Users/ippachi/.cache/dein/repos/github.com/Shougo/ddc.vim/denops/ddc/app.ts:130:35)
[denops]     at async Session.onEvent (file:///Users/ippachi/.cache/dein/repos/github.com/Shougo/ddc.vim/denops/ddc/app.ts:109:8)
[denops]     at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.0/session.ts:98:6)
[denops]     at async https://deno.land/x/msgpack_rpc@v3.1.0/session.ts:108:15
[denops]     at Session.call (https://deno.land/x/msgpack_rpc@v3.1.0/session.ts:207:13)
[denops]     at async Service.dispatch (file:///Users/ippachi/.cache/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service/service.ts:111:8)
[denops]     at async Session.invoke (file:///Users/ippachi/.cache/dein/repos/github.com/vim-denops/denops.vim/denops/@denops-private/service/host/nvim.ts:43:44)
[denops]     at async Session.dispatch (https://deno.land/x/msgpack_rpc@v3.1.0/session.ts:98:6)
[denops]     at async Session.handleNotification (https://deno.land/x/msgpack_rpc@v3.1.0/session.ts:129:10)
```

## Minimal init.vim for reproducing
```vim
set rtp+=~/.cache/dein/repos/github.com/Shougo/ddc.vim
set rtp+=~/.cache/dein/repos/github.com/Shougo/ddc-nvim-lsp
set rtp+=~/.cache/dein/repos/github.com/vim-denops/denops.vim
set rtp+=~/.cache/dein/repos/github.com/neovim/nvim-lspconfig

call ddc#custom#patch_global('sources', ['nvimlsp'])
call ddc#enable()

lua << EOF
  require'lspconfig'.solargraph.setup{
    init_options = {
      completion = false
    }
  }
EOF
```