### PR TITLE
Fix check of Nvim new api

### DIFF
--- a/lua/ddc_nvim_lsp.lua
+++ b/lua/ddc_nvim_lsp.lua
@@ -3,7 +3,7 @@ local api = vim.api
 local get_candidates = function(_, arg1, arg2)
   -- For neovim 0.6 breaking changes
   -- https://github.com/neovim/neovim/pull/15504
-  local result = vim.fn.has('nvim-0.6') == 1 and arg1 or arg2
+  local result = vim.fn.has('nvim-0.6') == 1 and type(arg1) == 'table' and arg1 or arg2
   if not result or result == 0 then
     return
   end


### PR DESCRIPTION
For nvim's breaking change compatibility, checking version is not enough. If HEAD users update only ddc, error is shown.