### PR TITLE
Use external modules

### DIFF
--- a/denops/ddc-sources/nvimlsp.ts
+++ b/denops/ddc-sources/nvimlsp.ts
@@ -10,6 +10,9 @@ import {
   Denops,
   vars,
 } from "https://deno.land/x/ddc_vim@v0.5.0/deps.ts#^";
+import {
+  CompletionItem,
+} from "https://deno.land/x/vscode_languageserver_types@v0.1.0/mod.ts"
 
 const LSP_KINDS = [
   "Text",
@@ -97,10 +100,7 @@ export class Source extends BaseSource {
     const results = await vars.g.get(
       denops,
       "ddc#source#lsp#_results",
-    ) as Record<
-      string,
-      unknown
-    >[];
+    ) as CompletionItem[];
 
     if (results.length == 0) {
       return [];
@@ -118,24 +118,21 @@ export class Source extends BaseSource {
     const candidates = results.map((v) => {
       let word = "";
 
-      if ("textEdit" in v && v["textEdit"]) {
-        const textEdit = v["textEdit"] as Record<string, any>;
-        if (
-          textEdit && "range" in textEdit &&
-          textEdit.range.start == textEdit.range.end
-        ) {
+      if (v.textEdit) {
+        const textEdit = v.textEdit
+        if ("range" in textEdit && textEdit.range.start == textEdit.range.end) {
           word = `${previousInput.slice(completePosition)}${textEdit.newText}`;
         } else {
           word = textEdit.newText;
         }
-      } else if ("insertText" in v) {
-        if ("insertText" in v && v.insertTextFormat != 1) {
-          word = ("entryName" in v ? v.entryName : v.label) as string;
+      } else if (v.insertText) {
+        if (v.insertTextFormat != 1) {
+          word = v.label
         } else {
-          word = v.insertText as string;
+          word = v.insertText
         }
       } else {
-        word = ("entryName" in v ? v.entryName : v.label) as string;
+        word = v.label
       }
 
       // Remove parentheses from word.
@@ -163,16 +160,13 @@ export class Source extends BaseSource {
       }
 
       if (v.detail) {
-        item.menu = v.detail as string;
+        item.menu = v.detail;
       }
 
       if (typeof v.documentation === "string") {
         item.info = v.documentation;
-      } else if (
-        v.documentation && typeof v.documentation === "object" &&
-        "value" in v.documentation
-      ) {
-        item.info = (v.documentation as any).value;
+      } else if (v.documentation && "value" in v.documentation) {
+        item.info = v.documentation.value;
       }
 
       return item;

--- a/denops/ddc-sources/nvimlsp.ts
+++ b/denops/ddc-sources/nvimlsp.ts
@@ -1,8 +1,10 @@
 import {
   BaseSource,
   Candidate,
-  Context,
 } from "https://deno.land/x/ddc_vim@v0.5.0/types.ts#^";
+import {
+  GatherCandidatesArguments,
+} from "https://deno.land/x/ddc_vim@v0.5.0/base/source.ts#^";
 import {
   batch,
   Denops,
@@ -54,12 +56,7 @@ export class Source extends BaseSource {
     });
   }
 
-  async gatherCandidates(args: {
-    denops: Denops,
-    context: Context,
-    sourceParams: Record<string, Params>,
-    completeStr: string,
-  }): Promise<Candidate[]> {
+  async gatherCandidates(args: GatherCandidatesArguments): Promise<Candidate[]> {
     const prevInput = await vars.g.get(args.denops, "ddc#source#lsp#_prev_input");
     const requested = await vars.g.get(args.denops, "ddc#source#lsp#_requested");
     if (args.context.input == prevInput && requested) {

--- a/denops/ddc-sources/nvimlsp.ts
+++ b/denops/ddc-sources/nvimlsp.ts
@@ -12,8 +12,9 @@ import {
 } from "https://deno.land/x/ddc_vim@v0.5.0/deps.ts#^";
 import {
   CompletionItem,
-} from "https://deno.land/x/vscode_languageserver_types@v0.1.0/mod.ts"
-import { equal } from "https://deno.land/x/equal@v1.5.0/mod.ts";
+} from "https://deno.land/x/vscode_languageserver_types@v0.1.0/mod.ts#^"
+
+import { equal } from "https://deno.land/x/equal@v1.5.0/mod.ts#^";
 
 const LSP_KINDS = [
   "Text",

--- a/denops/ddc-sources/nvimlsp.ts
+++ b/denops/ddc-sources/nvimlsp.ts
@@ -13,6 +13,7 @@ import {
 import {
   CompletionItem,
 } from "https://deno.land/x/vscode_languageserver_types@v0.1.0/mod.ts"
+import { equal } from "https://deno.land/x/equal@v1.5.0/mod.ts";
 
 const LSP_KINDS = [
   "Text",
@@ -120,7 +121,7 @@ export class Source extends BaseSource {
 
       if (v.textEdit) {
         const textEdit = v.textEdit
-        if ("range" in textEdit && textEdit.range.start == textEdit.range.end) {
+        if ("range" in textEdit && equal(textEdit.range.start, textEdit.range.end)) {
           word = `${previousInput.slice(completePosition)}${textEdit.newText}`;
         } else {
           word = textEdit.newText;


### PR DESCRIPTION
I am not sure what the policy is on using external modules and `entryName` handling, so I make a Draft PR.

#  Use the GatherCandidatesArguments from ddc.vim 2e4bf03 

This resolves `TS2416 [ERROR]: Property 'gatherCandidates' in type 'Source' is not assignable to the same property in base type 'BaseSource'.` error.

```
% deno run denops/ddc-sources/nvimlsp.ts
Check file:///home/haruyama/work/Vim/ddc-nvim-lsp/denops/ddc-sources/nvimlsp.ts
error: TS2339 [ERROR]: Property 'utime' does not exist on type 'typeof Deno'. 'Deno.utime' is an unstable API. Did you forget to run with the '--unstable' flag?
    await Deno.utime(dest, statInfo.atime, statInfo.mtime);
               ~~~~~
    at https://deno.land/std@0.104.0/fs/copy.ts:96:16

(snip)


TS2416 [ERROR]: Property 'gatherCandidates' in type 'Source' is not assignable to the same property in base type 'BaseSource'.
  Type '(args: { denops: Denops; context: Context; sourceParams: Record<string, Params>; completeStr: string; }) => Promise<Candidate[]>' is not assignable to type '({}: GatherCandidatesArguments) => Promise<Candidate[]>'.
    Types of parameters 'args' and '__0' are incompatible.
      Type 'GatherCandidatesArguments' is not assignable to type '{ denops: Denops; context: Context; sourceParams: Record<string, Params>; completeStr: string; }'.
        Types of property 'sourceParams' are incompatible.
          Type 'Record<string, unknown>' is not assignable to type 'Record<string, Params>'.
            Index signatures are incompatible.
              Type 'unknown' is not assignable to type 'Params'.
  async gatherCandidates(args: {
        ~~~~~~~~~~~~~~~~
    at file:///home/haruyama/work/Vim/ddc-nvim-lsp/denops/ddc-sources/nvimlsp.ts:57:9

Found 7 errors.
```

#  Use the CompletionItem from vscode_languageserver_types 98372d6 

This resolves some `(no-explicit-any)` problems from deno lint.

I did not know how to handle `entryName`, and I did not find `entryName` in [Language Server Protocol Specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/).
If `entryName` handling is needed, we cannot use vscode_languageserver_types as is.

# Use the equal from equal for checking the objects are equal c2d73fd

From https://basarat.gitbook.io/typescript/recap/equality#structural-equality

> If you want to compare two objects for structural equality ==/=== are not sufficient. e.g.

textEdit.range.{start,end} are [Position](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position),
so I think we should not use ==/===.
