### PR TITLE
Clean no-explicit-any problems from 'deno lint'

### DIFF
--- a/denops/@ddc-sources/nvimlsp.ts
+++ b/denops/@ddc-sources/nvimlsp.ts
@@ -168,9 +168,9 @@ export class Source extends BaseSource<Params> {
       };
 
       if (typeof v.kind === "number") {
-        const labels = params.kindLabels as any;
+        const labels = params.kindLabels;
         const kind = LSP_KINDS[v.kind - 1];
-        item.kind = (kind in labels as any ? labels[kind] : kind) as string;
+        item.kind = kind in labels ? labels[kind] : kind;
       } else if (v.insertTextFormat && v.insertTextFormat == 2) {
         item.kind = "Snippet";
       }


### PR DESCRIPTION
Clean the following problems.

```
% deno lint --unstable denops

(no-explicit-any) `any` type is not allowed
        const labels = params.kindLabels as any;
                                            ^^^
    at /home/haruyama/work/Vim/ddc-nvim-lsp/denops/@ddc-sources/nvimlsp.ts:171:44

    hint: Use a specific type other than `any`
    help: for further information visit https://lint.deno.land/#no-explicit-any

(no-explicit-any) `any` type is not allowed
        item.kind = (kind in labels as any ? labels[kind] : kind) as string;
                                       ^^^
    at /home/haruyama/work/Vim/ddc-nvim-lsp/denops/@ddc-sources/nvimlsp.ts:173:39

    hint: Use a specific type other than `any`
    help: for further information visit https://lint.deno.land/#no-explicit-any

Found 2 problems
Checked 1 file
```