### PR TITLE
Deal with LS that have id > 1

### DIFF
--- a/lua/ddc_nvim_lsp.lua
+++ b/lua/ddc_nvim_lsp.lua
@@ -20,7 +20,7 @@ local request_candidates = function(arguments, id)
 
   local func = function(responses)
     local all = {}
-    for _, r in ipairs(responses)  do
+    for _, r in pairs(responses)  do
       if r.result then
         local items = r.result.items or r.result
         for i = 1, #items do


### PR DESCRIPTION
Servers in results can have id larger than `1`. `ipairs` starts looping
in its id: `1`, `2`, ..., but the result table may have `3`, `4`, ...

I fixed to use `pairs` to loop all available items robustly.