### PR TITLE
Remove overwraped text which comes before complete position

### DIFF
--- a/denops/@ddc-sources/nvim-lsp.ts
+++ b/denops/@ddc-sources/nvim-lsp.ts
@@ -100,14 +100,20 @@ export class Source extends BaseSource<Params> {
       ) {
         if (v.textEdit) {
           const textEdit = v.textEdit;
-          if (
-            "range" in textEdit &&
-            textEdit.range.start.line == textEdit.range.end.line &&
-            textEdit.range.start.character == textEdit.range.end.character
-          ) {
-            word = `${input.slice(completePosition)}${textEdit.newText}`;
-          } else {
-            word = textEdit.newText;
+          word = textEdit.newText;
+          if ("range" in textEdit) {
+            const start = textEdit.range.start;
+            const end = textEdit.range.end;
+            if (start.line == end.line && start.character == end.character) {
+              word = `${input.slice(completePosition)}${word}`;
+            } else if (
+              start.character < completePosition &&
+              input.slice(start.character, completePosition) ==
+                word.slice(0, completePosition - start.character)
+            ) {
+              // remove overwraped text which comes before complete position
+              word = word.slice(completePosition - start.character);
+            }
           }
         } else if (v.insertText) {
           word = v.insertText;


### PR DESCRIPTION
If `textEdit` overwraps with input text which comes before `completePosition`, the overwrap must be deleted.

This is an example with denols.
before
![ddc-nvim-lsp_pr](https://user-images.githubusercontent.com/63794197/147410418-7c1fef92-bdbe-46b4-8b8c-f9de01608dbf.gif)

fixed
![ddc-nvim-lsp_pr_fixed](https://user-images.githubusercontent.com/63794197/147410430-6b78fa27-94ba-4efb-979c-021a79224948.gif)
