### PR TITLE
Improve creation of word from snippet items

### DIFF
--- a/denops/@ddc-sources/nvim-lsp.ts
+++ b/denops/@ddc-sources/nvim-lsp.ts
@@ -1,11 +1,11 @@
 import {
   BaseSource,
   Candidate,
-} from "https://deno.land/x/ddc_vim@v0.17.0/types.ts#^";
-import { assertEquals } from "https://deno.land/x/ddc_vim@v0.17.0/deps.ts#^";
+} from "https://deno.land/x/ddc_vim@v1.3.0/types.ts#^";
+import { assertEquals } from "https://deno.land/x/ddc_vim@v1.3.0/deps.ts#^";
 import {
   GatherCandidatesArguments,
-} from "https://deno.land/x/ddc_vim@v0.17.0/base/source.ts#^";
+} from "https://deno.land/x/ddc_vim@v1.3.0/base/source.ts#^";
 import {
   CompletionItem,
   InsertTextFormat,

--- a/denops/@ddc-sources/nvim-lsp.ts
+++ b/denops/@ddc-sources/nvim-lsp.ts
@@ -2,6 +2,7 @@ import {
   BaseSource,
   Candidate,
 } from "https://deno.land/x/ddc_vim@v0.17.0/types.ts#^";
+import { assertEquals } from "https://deno.land/x/ddc_vim@v0.17.0/deps.ts#^";
 import {
   GatherCandidatesArguments,
 } from "https://deno.land/x/ddc_vim@v0.17.0/base/source.ts#^";
@@ -188,3 +189,52 @@ export class Source extends BaseSource<Params> {
     };
   }
 }
+
+Deno.test("getWord", () => {
+  assertEquals(
+    getWord(
+      {
+        "label": '"Cascadia Mono"',
+        "textEdit": {
+          "range": {
+            "end": { "character": 14, "line": 39 },
+            "start": { "character": 12, "line": 39 },
+          },
+          "newText": '"Cascadia Mono"',
+        },
+        "insertText": '"Cascadia Mono"',
+        "insertTextFormat": 2,
+      },
+      '"fontFace": "',
+      13,
+    ),
+    'Cascadia Mono"',
+  );
+  assertEquals(
+    getWord(
+      {
+        "label": "fig:HfO2",
+        "textEdit": {
+          "range": {
+            "end": { "character": 10, "line": 52 },
+            "start": { "character": 5, "line": 52 },
+          },
+          "newText": "fig:HfO2",
+        },
+      },
+      "\\ref{fig:h",
+      9,
+    ),
+    "HfO2",
+  );
+});
+
+Deno.test("getSnippetWord", () => {
+  // test cases from nvim-cmp
+  assertEquals(getSnippetWord("all: $0;"), "all:");
+  assertEquals(getSnippetWord("print"), "print");
+  assertEquals(getSnippetWord("$variable"), "$variable");
+  assertEquals(getSnippetWord("print()"), "print");
+  assertEquals(getSnippetWord('["cmp#confirm"]'), '["cmp#confirm"]');
+  assertEquals(getSnippetWord('"devDependencies":'), '"devDependencies"');
+});

--- a/denops/@ddc-sources/nvim-lsp.ts
+++ b/denops/@ddc-sources/nvim-lsp.ts
@@ -48,9 +48,7 @@ function getWord(
   input: string,
   completePosition: number,
 ): string {
-  const label = item.label.replace(/^\s+/, "");
-
-  let word = label;
+  let word = item.label.trimStart();
 
   if (item.textEdit) {
     const textEdit = item.textEdit;
@@ -237,4 +235,5 @@ Deno.test("getSnippetWord", () => {
   assertEquals(getSnippetWord("print()"), "print");
   assertEquals(getSnippetWord('["cmp#confirm"]'), '["cmp#confirm"]');
   assertEquals(getSnippetWord('"devDependencies":'), '"devDependencies"');
+  assertEquals(getSnippetWord('\\"devDependencies\\":'), '"devDependencies"');
 });


### PR DESCRIPTION
## problem
When the lsp item has snippet textEdit, the source inserts `CompletionItem.label`, which is sometimes invalid to insert.

## solution
Create `word` from `insertText` or `textEdit.newText`. This is the same way as vim-lsp or nvim-cmp.
Of course, I took the past problems of creating `word` like #25 into consideration.

## screenshot
before
![ddc-nvim-lsp_pr2](https://user-images.githubusercontent.com/63794197/153603701-ac6858a7-da07-4df7-b93f-d371b6b8a8d7.gif)


@snippet-expantion
![ddc-nvim-lsp_pr2_fixed](https://user-images.githubusercontent.com/63794197/153603514-ec65c9a9-4628-4ba1-ab89-8ae3ecafb518.gif)
